### PR TITLE
mysqlの照合順序をlatin1_swedish_ciからutf8mb4_unicode_ciに変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 mysql/
+db/data/

--- a/db/my.conf
+++ b/db/my.conf
@@ -1,6 +1,19 @@
+# MySQLサーバーへの設定
 [mysqld]
-character-set-server=utf8mb4
-collation-server=utf8mb4_unicode_ci
+# 文字コード/照合順序の設定
+character-set-server = utf8mb4
+collation-server = utf8mb4_bin
 
+# タイムゾーンの設定
+default-time-zone = SYSTEM
+log_timestamps = SYSTEM
+
+# mysqlオプションの設定
+[mysql]
+# 文字コードの設定
+default-character-set = utf8mb4
+
+# mysqlクライアントツールの設定
 [client]
-default-character-set=utf8mb4
+# 文字コードの設定
+default-character-set = utf8mb4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,9 +40,9 @@ services:
     ports:
       - '3306:3306'
     volumes:
-      - ./mysql/data:/var/lib/mysql
-      - ./mysql/my.cnf:/etc/mysql/conf.d/my.cnf
-      - ./mysql/sql:/docker-entrypoint-initdb.d
+      - ./db/data:/var/lib/mysql
+      - ./db/my.conf:/etc/mysql/conf.d/my.cnf
+      - ./db/sql:/docker-entrypoint-initdb.d
 
   phpmyadmin:
     image: phpmyadmin/phpmyadmin


### PR DESCRIPTION
# 概要
* mysqlの照合順序がデフォルトでlatin1_swedish_ciになり学年などの情報をDBに格納することができない不具合をデフォルトの照合順序をutf8mb4_unicode_ciにすることで解決しました
* docker-compose.ymlとmy.confを修正することで解決しました
# 動作確認
* phpMyAdminから照合順序がutf8mb4_unicode_ciになっていることを確認しました