### PR TITLE
mysqlの照合順序をutf8mb4に変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,11 +32,16 @@ services:
 
   mysql:
     image: mysql/mysql-server:5.7.28
+    command: 
+      - mysqld
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
     environment:
       MYSQL_ROOT_PASSWORD: admin
       MYSQL_USER: admin
       MYSQL_PASSWORD: admin
       MYSQL_DATABASE: go_auth
+      TZ: "Asia/Tokyo"
     ports:
       - '3306:3306'
     volumes:


### PR DESCRIPTION
# 概要
* mysqlの照合順序をutf8mb4に変更しました
* 実行するときにはdb/dataとdb/mysqlを削除し、コンテナも削除してから実行すると反映されます
* 前のプルリクエストでは、一度docker-compose.ymlを変更（今回のpull request）した状態でうまくいくことを確認後、db/my.confを変更してdocker-compose.ymlを元に戻した状態でうまくいったため（本来は失敗するはずがdb/dataとdb/mysqlを削除してなかったため成功したと考えられる）後者の方でpull requestを送ってしまいました
# 備考
* タイムゾーンを東京に設定しました